### PR TITLE
[enh] Disable automatic update checking

### DIFF
--- a/sources/conf/dokuwiki.php
+++ b/sources/conf/dokuwiki.php
@@ -149,7 +149,7 @@ $conf['rss_update'] = 5*60;              //Update the RSS feed every n seconds (
 $conf['rss_show_summary'] = 1;           //Add revision summary to title? 0|1
 
 /* Advanced Settings */
-$conf['updatecheck'] = 1;                //automatically check for new releases?
+$conf['updatecheck'] = 0;                //automatically check for new releases?
 $conf['userewrite']  = 0;                //this makes nice URLs: 0: off 1: .htaccess 2: internal
 $conf['useslash']    = 0;                //use slash instead of colon? only when rewrite is on
 $conf['sepchar']     = '_';              //word separator character in page names; may be a


### PR DESCRIPTION
Automatic update checking should be disabled since it's done with YunoHost - and due to some folder rights conflicts it's not possible to do it using the upgrade plugin of dokuwiki.
