### PR TITLE
Allow dokuwiki to write templates

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -53,9 +53,9 @@ sudo find $final_path -type f -print0 | sudo xargs -0 chmod 0644
 sudo find $final_path -type d -print0 | sudo xargs -0 chmod 0755
 sudo chown -R root: $final_path
 
-# except for conf, data, some data subfolders, and lib/plugin, where www-data must have write permissions
-sudo chown -R www-data:root $final_path/{conf,data,data/attic,data/cache,data/index,data/locks,data/media*,data/meta,data/pages,data/tmp,lib/plugins}
-sudo chmod -R 700           $final_path/{conf,data,data/attic,data/cache,data/index,data/locks,data/media*,data/meta,data/pages,data/tmp,lib/plugins}
+# except for conf, data, some data subfolders,lib/plugin and lib/tpl, where www-data must have write permissions
+sudo chown -R www-data:root $final_path/{conf,data,data/attic,data/cache,data/index,data/locks,data/media*,data/meta,data/pages,data/tmp,lib/plugins,lib/tpl}
+sudo chmod -R 700           $final_path/{conf,data,data/attic,data/cache,data/index,data/locks,data/media*,data/meta,data/pages,data/tmp,lib/plugins,lib/tpl}
 
 # Modify Nginx configuration file and copy it to Nginx conf directory
 sed -i "s@YNH_WWW_LOCATION@$location@g" ../conf/nginx.conf


### PR DESCRIPTION
See https://dev.yunohost.org/issues/554

Although when dokuwiki is updated to ponder stibbons maybe this isn't needed? 

> From version Ponder Stibbons and upward the installation and upgrading of templates is automated by the Extension Manager.

https://www.dokuwiki.org/template#installing_templates