### PR TITLE
Enable uploads bigger than 1Mb

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -8,6 +8,8 @@ location __PATHTOCHANGE__ {
     index index.php;
     try_files $uri $uri/ index.php;
 
+    client_max_body_size 25M;
+    
     location ~ [^/]\.php(/|$) {
       fastcgi_split_path_info ^(.+?\.php)(/.*)$;
       fastcgi_pass unix:/var/run/php5-fpm-__NAMETOCHANGE__.sock;


### PR DESCRIPTION
By default, one can't upload anything bigger than 1Mb.
This PR applies the official DokuWiki guidance [here](https://www.dokuwiki.org/faq:uploadsize#nginx_users).