### PR TITLE
Url rewriting

### DIFF
--- a/conf/local.protected.php
+++ b/conf/local.protected.php
@@ -23,9 +23,6 @@ $conf['plugin']['authldap']['port']        = 389;
 $conf['plugin']['authldap']['version']     = 3;
 $conf['plugin']['authldap']['usertree']    = 'ou=users,dc=yunohost,dc=org';
 $conf['plugin']['authldap']['userfilter']  = '(&(uid=%{user})(objectClass=posixAccount))';
-# no groups
-#$conf['plugin']['authldap']['grouptree']   = 'ou=Group, dc=server, dc=tld';
-#$conf['plugin']['authldap']['groupfilter'] = '(&(objectClass=posixGroup)(|(gidNumber=%{gid})(memberUID=%{user})))'; 
 
 /* Advanced Settings */
 $conf['updatecheck'] = 0;                //automatically check for new releases?

--- a/conf/local.protected.php
+++ b/conf/local.protected.php
@@ -26,5 +26,9 @@ $conf['plugin']['authldap']['userfilter']  = '(&(uid=%{user})(objectClass=posixA
 
 /* Advanced Settings */
 $conf['updatecheck'] = 0;                //automatically check for new releases?
+
 // Taken from previous package. Don't know what it does. Maybe Yunohost corner logo ?
 $conf['cssdatauri']  = 512;              //Maximum byte size of small images to embed into CSS, won't work on IE<8
+
+// URL Rewriting is handled by the webserver
+$conf['userewrite'] = 1;                 // See https://www.dokuwiki.org/config:userewrite

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,3 +1,8 @@
+# config built from these sources:
+# https://www.dokuwiki.org/install:nginx
+# https://www.nginx.com/resources/wiki/start/topics/recipes/dokuwiki/
+# https://forum.dokuwiki.org/thread/17126
+
 #sub_path_only rewrite ^__PATH__$ __PATH__/ permanent;
 location __PATH__/ {
 
@@ -14,7 +19,8 @@ location __PATH__/ {
   # Common parameter to increase upload size limit in conjuction with dedicated php-fpm file
   client_max_body_size 25M;
 
-  try_files $uri $uri/ index.php;
+  try_files $uri $uri/ @dokuwiki;
+
   location ~ [^/]\.php(/|$) {
     fastcgi_split_path_info ^(.+?\.php)(/.*)$;
     fastcgi_pass unix:/var/run/php/php7.0-fpm-__NAME__.sock;
@@ -44,4 +50,14 @@ location __PATH__/ {
 
   # Include SSOWAT user panel.
   include conf.d/yunohost_panel.conf.inc;
+}
+
+# rewrites "doku.php/" out of the URLs if you set the userwrite setting to .htaccess in dokuwiki confi$
+location @dokuwiki {
+  rewrite ^__PATH__/_media/(.*)          __PATH__/lib/exe/fetch.php?media=$1 last;
+  rewrite ^__PATH__/_detail/(.*)         __PATH__/lib/exe/detail.php?media=$1 last;
+  rewrite ^__PATH__/_export/([^/]+)/(.*) __PATH__/doku.php?do=export_$1&id=$2 last;
+  # Specifig to "tag plugin". Added here to allow plugin to work if installed
+  rewrite ^__PATH__/tag/(.*)             __PATH__/doku.php?id=tag:$1&do=showtag&tag=tag:$1 last;
+  rewrite ^__PATH__/(.*)                 __PATH__/doku.php?id=$1&$args last;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
         "es": "DokuWiki es un sistema de Wiki de uso sencillicimo y compatible con los estándares.",
         "it": "DokuWiki è un Wiki aderente agli standard, semplice da usare, finalizzato principalmente alla creazione di documentazione di qualsiasi tipo."
     },
-    "version": "2018-04-22a~ynh2",
+    "version": "2018-04-22a~ynh3",
     "url": "https://www.dokuwiki.org",
     "license": "GPL-2.0-or-later",
     "maintainer": {

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -19,6 +19,6 @@
 - [ ] **Approval (LGTM)** : 
 - [ ] **Approval (LGTM)** : 
 - **CI succeeded** : 
-[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/dokuwiki_ynh%20PR-NUM-/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/dokuwiki_ynh%20PR-NUM-/)  
+[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/dokuwiki_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/dokuwiki_ynh%20PR-NUM-/)  
 *Please replace '-NUM-' in this link by the PR number.*  
 When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -19,7 +19,6 @@
 - [ ] **Approval (LGTM)** : 
 - [ ] **Approval (LGTM)** : 
 - **CI succeeded** : 
-[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/dokuwiki_ynh%20-BRANCH-%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/dokuwiki_ynh%20-BRANCH-%20(Official)/) *Please replace '-BRANCH-' in this link for a PR from a local branch.*  
-or  
-[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/dokuwiki_ynh%20PR-NUM-%20(Official_fork)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/dokuwiki_ynh%20PR-NUM-%20(Official_fork)/) *Replace '-NUM-' by the PR number in this link for a PR from a forked repository.*  
+[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/dokuwiki_ynh%20PR-NUM-/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/dokuwiki_ynh%20PR-NUM-/)  
+*Please replace '-NUM-' in this link by the PR number.*  
 When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.


### PR DESCRIPTION
## Problem
- Fix https://github.com/YunoHost-Apps/dokuwiki_ynh/issues/51

## Solution
- Add URL rewrite
- Install tested manually on "root domain" ( wiki.myDomain.org ) and "sub path" (myDomain.org/dokuwiki)
- Tested using "change URL" from YunoHost web admin too

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [X] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/dokuwiki_ynh%20PR54/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/dokuwiki_ynh%20PR54/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
