### PR TITLE
[fix] dedicated named location per $app

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -19,7 +19,7 @@ location __PATH__/ {
   # Common parameter to increase upload size limit in conjuction with dedicated php-fpm file
   client_max_body_size 25M;
 
-  try_files $uri $uri/ @dokuwiki;
+  try_files $uri $uri/ @__NAME__ ;
 
   location ~ [^/]\.php(/|$) {
     fastcgi_split_path_info ^(.+?\.php)(/.*)$;
@@ -53,7 +53,7 @@ location __PATH__/ {
 }
 
 # rewrites "doku.php/" out of the URLs if you set the userwrite setting to .htaccess in dokuwiki confi$
-location @dokuwiki {
+location @__NAME__  {
   rewrite ^__PATH__/_media/(.*)          __PATH__/lib/exe/fetch.php?media=$1 last;
   rewrite ^__PATH__/_detail/(.*)         __PATH__/lib/exe/detail.php?media=$1 last;
   rewrite ^__PATH__/_export/([^/]+)/(.*) __PATH__/doku.php?do=export_$1&id=$2 last;


### PR DESCRIPTION
fix multiple install on subdomains

Before this fix
app1 => @dokuwiki   - works
app2 => @dokuwiki   - fails

After \o/
app1 => @app1       - works
app2 => @app2       - works

-------

## Problem
- Activating "URL rewriting" broke multiple install on subfolders
- All dokuwiki apps send their data to the same [named location](http://nginx.org/en/docs/http/ngx_http_core_module.html#location) `@dokuwiki`
  - there can only be one functionnal instance per domain

## Solution
- Create a dedicated named location per DokuWiki installation

## Test
On the same domain (`root` or `subdomain`), install

1. <https://myDomain/dokuwiki1>
2. <https://myDomain/dokuwiki2>

Visit <https://myDomain/dokuwiki2> and go to another page than `$home` (like `$admin` or create a `$new page`)

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [X] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/dokuwiki_ynh%20PR61/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/dokuwiki_ynh%20PR61/)  

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
