### PR TITLE
[Fix] caching pictures that didn't work

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -39,12 +39,12 @@ location __PATH__/ {
   }
 
   # Deny Access to htaccess-Files for Apache
-  location ~ /\.ht {
+  location ~ __PATH__/\.ht {
     deny all;
   }
 
   # Serve static files
-  location ~ ^/lib.*\.(gif|png|ico|jpg)$ {
+  location ~ ^__PATH__/lib.*\.(gif|png|ico|jpg)$ {
     expires 30d;
   }
 


### PR DESCRIPTION
Set HTTP Headers 'Expires' on the correct PATH...

## Problem
- Caching didn't work on pictures (HTTP header not set)

## Solution
- Fix path in nginx

After fix, you will have the missing header

![dokuwiki_issue57](https://user-images.githubusercontent.com/17145502/80036353-dbedc900-84f1-11ea-8e46-133e8a784168.png)

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [X] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/dokuwiki_ynh%20PR65/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/dokuwiki_ynh%20PR65/)  

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
